### PR TITLE
Fixed pillow and expat errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex \
 		postgresql-dev \
 		libjpeg-turbo-dev \
 		zlib-dev \
+		expat-dev \
 		git \
 	&& pyvenv /venv \
 	&& /venv/bin/pip install -U pip \

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,5 +2,5 @@ Django>=2.1,<2.2
 django-dotenv==1.4.1
 wagtail>=2.3,<2.4
 wagtailfontawesome>=1.1.3,<1.2
-Pillow==4.0.0
+Pillow==5.4.1
 django-cors-headers>=2.4.0,<3.0


### PR DESCRIPTION
I followed the instructions in the README file, but ran into a couple of errors. After fixing them, I was able to successfully run the demo with docker-compose and view page previews on http://localhost:8020.